### PR TITLE
chore(aap): bump operator channel to stable-2.7-cluster-scoped

### DIFF
--- a/manifests/ansible/ansible-app-subscription.yaml
+++ b/manifests/ansible/ansible-app-subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ansible-automation-platform-operator
   namespace: aap
 spec:
-  channel: stable-2.6-cluster-scoped
+  channel: stable-2.7-cluster-scoped
   name: ansible-automation-platform-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
## What

Bumps the **Ansible Automation Platform** operator Subscription channel:
`stable-2.6-cluster-scoped` → `stable-2.7-cluster-scoped` (operator 2.6 → 2.7).

`installPlanApproval` stays **Manual** — applying this records the channel; the resulting 2.7 InstallPlan is approved separately.

## Why this is the whole change

The 2.7 CSV `aap-operator.v2.7.0-0.1779173658` carries `olm.skipRange: ">=2.6.0-0 <2.7.1"`, which covers the installed `2.6.0+0.1774648973`. So OLM upgrades **directly** to 2.7 with no intermediate 2.6 patch CSV. No CRD/spec change is needed for the operand (`AnsibleAutomationPlatform/aap` is version-agnostic).

Corrects a stale assumption in the issue: the Subscription is **already** Terraform-managed here (`kubernetes_manifest.aap-subscription`) — there was no out-of-band IaC gap, just a channel to bump.

## Verification target (post-apply + InstallPlan approval)

- Operator CSV → `aap-operator.v2.7.0-0.1779173658`, Subscription healthy on `stable-2.7-cluster-scoped`
- `AnsibleAutomationPlatform/aap` Running/Successful; controller, EDA, hub pods Ready
- Route `aap-aap.apps.openshift-01...` serves the UI/API

Refs tfo-apj-demos/terraform-openshift-platform-apps#7

🤖 Generated with [Claude Code](https://claude.com/claude-code)