### PR TITLE
feat: install CNV and MTV operators via OLM

### DIFF
--- a/cnv.tf
+++ b/cnv.tf
@@ -1,0 +1,31 @@
+locals {
+  cnv_operatorgroup = file("${path.module}/manifests/cnv/cnv-operatorgroup.yaml")
+  cnv_subscription  = file("${path.module}/manifests/cnv/cnv-subscription.yaml")
+}
+
+resource "kubernetes_namespace" "cnv" {
+  metadata {
+    name = "openshift-cnv"
+  }
+
+  lifecycle {
+
+    ignore_changes = [
+      metadata.0.annotations["openshift.io/sa.scc.mcs"],
+      metadata.0.annotations["openshift.io/sa.scc.supplemental-groups"],
+      metadata.0.annotations["openshift.io/sa.scc.uid-range"],
+      metadata.0.labels
+    ]
+  }
+}
+
+
+resource "kubernetes_manifest" "cnv_operatorgroup" {
+  depends_on = [resource.kubernetes_namespace.cnv]
+  manifest   = provider::kubernetes::manifest_decode(local.cnv_operatorgroup)
+}
+
+resource "kubernetes_manifest" "cnv_subscription" {
+  depends_on = [resource.kubernetes_namespace.cnv]
+  manifest   = provider::kubernetes::manifest_decode(local.cnv_subscription)
+}

--- a/manifests/cnv/cnv-operatorgroup.yaml
+++ b/manifests/cnv/cnv-operatorgroup.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: kubevirt-hyperconverged-group
+  namespace: openshift-cnv
+spec:
+  targetNamespaces:
+    - openshift-cnv

--- a/manifests/cnv/cnv-subscription.yaml
+++ b/manifests/cnv/cnv-subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kubevirt-hyperconverged
+  namespace: openshift-cnv
+spec:
+  channel: stable
+  name: kubevirt-hyperconverged
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic

--- a/manifests/mtv/mtv-operatorgroup.yaml
+++ b/manifests/mtv/mtv-operatorgroup.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: migration
+  namespace: openshift-mtv
+spec:
+  targetNamespaces:
+    - openshift-mtv

--- a/manifests/mtv/mtv-subscription.yaml
+++ b/manifests/mtv/mtv-subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: mtv-operator
+  namespace: openshift-mtv
+spec:
+  channel: release-v2.10
+  name: mtv-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic

--- a/mtv.tf
+++ b/mtv.tf
@@ -1,0 +1,31 @@
+locals {
+  mtv_operatorgroup = file("${path.module}/manifests/mtv/mtv-operatorgroup.yaml")
+  mtv_subscription  = file("${path.module}/manifests/mtv/mtv-subscription.yaml")
+}
+
+resource "kubernetes_namespace" "mtv" {
+  metadata {
+    name = "openshift-mtv"
+  }
+
+  lifecycle {
+
+    ignore_changes = [
+      metadata.0.annotations["openshift.io/sa.scc.mcs"],
+      metadata.0.annotations["openshift.io/sa.scc.supplemental-groups"],
+      metadata.0.annotations["openshift.io/sa.scc.uid-range"],
+      metadata.0.labels
+    ]
+  }
+}
+
+
+resource "kubernetes_manifest" "mtv_operatorgroup" {
+  depends_on = [resource.kubernetes_namespace.mtv]
+  manifest   = provider::kubernetes::manifest_decode(local.mtv_operatorgroup)
+}
+
+resource "kubernetes_manifest" "mtv_subscription" {
+  depends_on = [resource.kubernetes_namespace.mtv]
+  manifest   = provider::kubernetes::manifest_decode(local.mtv_subscription)
+}


### PR DESCRIPTION
## What

Installs two Red Hat operators via OLM, mirroring the existing `certmanager.tf` subscription pattern (namespace + `OperatorGroup` + `Subscription`, wired through `provider::kubernetes::manifest_decode(file(...))`):

- **OpenShift Virtualization (CNV)** — `kubevirt-hyperconverged`, channel `stable`, source `redhat-operators` (targets **v4.18.36**). Namespace `openshift-cnv`, OperatorGroup `kubevirt-hyperconverged-group` (targetNamespaces: `openshift-cnv`).
- **Migration Toolkit for Virtualization (MTV)** — `mtv-operator`, channel `release-v2.10`, source `redhat-operators` (targets **v2.10.7**). Namespace `openshift-mtv`, OperatorGroup `migration` (OwnNamespace / targetNamespaces: `openshift-mtv` — MTV supports OwnNamespace only).

Both subscriptions use `installPlanApproval: Automatic`.

## Files

- `cnv.tf`, `manifests/cnv/cnv-operatorgroup.yaml`, `manifests/cnv/cnv-subscription.yaml`
- `mtv.tf`, `manifests/mtv/mtv-operatorgroup.yaml`, `manifests/mtv/mtv-subscription.yaml`

Each `.tf` is self-contained (its own `locals {}` block) exactly like `certmanager.tf`, and the namespaces use the same SCC-annotation/labels `ignore_changes` lifecycle block. `terraform fmt` clean.

## Why the operator CRs are NOT here

The operator Custom Resources (`HyperConverged` for CNV, `ForkliftController` for MTV) are intentionally delivered in a **separate apps-repo PR** (`terraform-openshift-platform-apps`). Their CRDs (`hco.kubevirt.io`, `forklift.konveyor.io`) do not exist until these operators install, and `kubernetes_manifest` fetches the CRD schema at plan time — so bundling them here would break the plan. These operator subscriptions plan fine because the OLM CRDs (`Subscription`/`OperatorGroup`) already exist cluster-wide.

## Notes

- No `terraform init/plan/apply` was run (no creds); verified only with `terraform fmt -check`.
- **Lab caveat:** nested OpenShift Virtualization on GCVE is a **functional lab**, not a supported production topology. This is not a supported Red Hat configuration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces cluster-wide operator subscriptions that pull and auto-approve install plans from `redhat-operators`, affecting virtualization and migration capabilities on apply.
> 
> **Overview**
> Adds Terraform to install **OpenShift Virtualization (CNV)** and **Migration Toolkit for Virtualization (MTV)** through OLM, using the same pattern as `certmanager.tf`: dedicated namespace, `OperatorGroup`, and `Subscription` manifests decoded via `kubernetes_manifest`.
> 
> CNV lands in `openshift-cnv` with `kubevirt-hyperconverged` on channel `stable` from `redhat-operators`. MTV lands in `openshift-mtv` with `mtv-operator` on `release-v2.10`, also with automatic install plan approval. Both namespaces reuse the OpenShift SCC annotation/label `ignore_changes` lifecycle block used elsewhere in this repo.
> 
> Operator instance CRs (`HyperConverged`, `ForkliftController`) are intentionally omitted here so plan-time CRD lookups do not fail before these subscriptions install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75fad92e22838d2cce31cbe96fdc2eb89e9defb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->