### PR TITLE
A5: pin root required_version = ~> 1.14.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,8 @@
 terraform {
+  # Pin to the workspace's Terraform version line (openshift-platform-config runs
+  # ~> 1.14.0) so a stray local/older CLI can't operate on this state.
+  required_version = "~> 1.14.0"
+
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
Adds `required_version = "~> 1.14.0"` to the root `terraform {}` block, matching the workspace's TF version pin. Prevents a stray local/older CLI from operating on the remote state. **No infrastructure change** (version constraint only).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version constraint and comments only; no runtime or resource changes.
> 
> **Overview**
> Adds **`required_version = "~> 1.14.0"`** to the root `terraform {}` block in `versions.tf`, aligned with the openshift-platform-config workspace Terraform line.
> 
> This is a **CLI/state guardrail only**: Terraform versions outside `1.14.x` are rejected before plan/apply, so an older or mismatched local CLI cannot touch remote state. **No provider versions, resources, or infrastructure behavior change.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c01376906cafa29a3e632acc45818b517df4793a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->